### PR TITLE
Adding basic pages for routing

### DIFF
--- a/src/Components/Header.tsx
+++ b/src/Components/Header.tsx
@@ -1,11 +1,16 @@
 import React from 'react';
+import styled from 'styled-components';
+
+const CoopHeader = styled.header`
+    background-color: orange
+`;
 
 class Header extends React.Component {
     render() {
         return (
-            <header className="App-header">
+            <CoopHeader className="App-header">
                 <h1>Food Coop</h1>
-            </header>
+            </CoopHeader>
         );
     }
 }

--- a/src/Pages/Cart.tsx
+++ b/src/Pages/Cart.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Header from '../Components/Header';
+import { RouteComponentProps, Link } from '@reach/router';
+import ProductList from '../Components/ProductList';
+
+class Dashboard extends React.Component<RouteComponentProps> {
+    render() {
+        return (
+            <div className="cart-page-container">
+                <Header/>
+                <h3>CART CART CART</h3>
+                <h2>checkout all dem products</h2>
+                <ProductList/>
+                <Link to="/">Back to dashboard</Link>
+            </div>
+        );
+    }
+}
+
+export default Dashboard;

--- a/src/Pages/Dashboard.tsx
+++ b/src/Pages/Dashboard.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Header from '../Components/Header';
+import { RouteComponentProps, Link } from '@reach/router';
+
+class Dashboard extends React.Component<RouteComponentProps> {
+    render() {
+        return (
+            <div className="product-page-container">
+                <Header/>
+                <h3>This is the dashboard</h3>
+                <h2>Explore by: </h2>
+                <Link to="/products">Products</Link>
+                <Link to="/producers">Producers</Link>
+                <h2>Examine your Cart</h2>
+                <Link to="/cart">Buy some great shit</Link>
+            </div>
+        );
+    }
+}
+
+export default Dashboard;

--- a/src/Pages/ProducerDetail.tsx
+++ b/src/Pages/ProducerDetail.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Header from '../Components/Header';
+import { RouteComponentProps, Link } from '@reach/router';
+
+interface ProducerDetailProps extends RouteComponentProps {
+    id: string;
+};
+
+const ProducerDetail = (props: ProducerDetailProps) => (
+    <div>
+        <h2>Producer {props.id} </h2>
+    </div>
+)
+
+// ^^^ that is a functional compontent. Seems like a simple page for now so i did it that way...
+// export class ProducerDetail extends React.Component<ProducerDetailProps> {
+//     render() {
+//         return (
+//             <div className="producer-detail-page-container">
+//                 <Header/>
+//                 <h3>This here is Producer {this.props.id}</h3>
+//                 <div>Product list filtered for producer prods</div>
+//             </div>
+//         );
+//     }
+// }
+
+export default ProducerDetail;

--- a/src/Pages/Producers.tsx
+++ b/src/Pages/Producers.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Header from '../Components/Header';
+import { RouteComponentProps, Link } from '@reach/router';
+
+class Producers extends React.Component<RouteComponentProps> {
+    render() {
+        return (
+            <div className="producer-page-container">
+                <Header/>
+                <h3>This here is some Producer Page ISH</h3>
+                <div>CATEGORIES</div>
+                <div>this is a producer list</div>
+                <Link to="1">Producer 1s detail page</Link>
+            </div>
+        );
+    }
+}
+
+export default Producers;

--- a/src/Pages/Products.tsx
+++ b/src/Pages/Products.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Header from '../Components/Header';
 import ProductList from '../Components/ProductList';
-import { RouteComponentProps } from '@reach/router';
+import { RouteComponentProps, Link } from '@reach/router';
 
 class Products extends React.Component<RouteComponentProps> {
     render() {
@@ -10,6 +10,7 @@ class Products extends React.Component<RouteComponentProps> {
                 <Header/>
                 <h3>This here is some Product Page ISH</h3>
                 <ProductList/>
+                <Link to="/cart">View Cart</Link>
             </div>
         );
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,13 +4,44 @@ import './index.css';
 import App from './App';
 import { Router } from '@reach/router'
 import Login from './Pages/Login';
-import Products from './Pages/Products'
+import Products from './Pages/Products';
+import Dashboard from './Pages/Dashboard';
+import Producers from './Pages/Producers';
+import ProducerDetail from './Pages/ProducerDetail';
+import Cart from './Pages/Cart';
+import { prependOnceListener } from 'cluster';
 
 
+/***
+ * Routing behind the whole thing
+ * Setup each page with a default and all that
+ * AUTENTICATION(?)
+ * Things we have:
+ * - Product Search
+ * - Login
+ * - Producer Search (ProducerList)
+ * - Producer Detail (ProductList)
+ * 
+ * 
+ * Pages we need:
+ * - Register page
+ * - Categories/Filtering
+ * - Producer Managenent
+ * 
+ * Comp/Modals:
+ * - Product Model
+ * - Cart Model
+ * 
+ */
 ReactDOM.render(
     <Router>
-        <Login path="/login" />
-        <Products path="/products"/>
+        <Login path="login" />
+        <Dashboard path="/"/>
+        <Products path="products"/>
+        <Producers path="producers"/>
+        <ProducerDetail path="producers/:producerId" id="1"/> 
+        <Cart path="cart"/>
     </Router>, document.getElementById('root')
 );
 
+// how in the actual %^$# do we get information from the route and pass to props??


### PR DESCRIPTION
This is just to get a simple frontend page structure out.

We are using Reach Router (https://reach.tech/router).
Currently I am trying to figure out how to pass props from the route....
The react component needs the props to be passed explicitly because of typescript. But reach router lets you just pass it down to the component through the route... needs more investigation.